### PR TITLE
Patch to remove extra skill points/saving throw proficiencies 

### DIFF
--- a/SolastaLevel20/Patches/CharacterBuildingManagerPatcher.cs
+++ b/SolastaLevel20/Patches/CharacterBuildingManagerPatcher.cs
@@ -52,7 +52,7 @@ namespace SolastaLevel20.Patches
         {
             internal static void Prefix(CharacterBuildingManager __instance, List<FeatureDefinition> grantedFeatures, string tag, bool clearPrevious = true, string optionalTagToCheck = null)
             {
-                //If we are adding a level higher than level 1, exclude some features that would normally be added to a level 1 character
+                //If we are adding a level higher than level 1, exclude some features that would normally be added to a level 1 character but should not be added to a multiclass character
                 if (__instance.HeroCharacter.ClassesHistory.Count > 1)
                 {
                     grantedFeatures.RemoveAll(feature => FeaturesToExcludeFromMulticlassLevels.Contains(feature));

--- a/SolastaLevel20/Patches/CharacterBuildingManagerPatcher.cs
+++ b/SolastaLevel20/Patches/CharacterBuildingManagerPatcher.cs
@@ -1,5 +1,8 @@
 ﻿using HarmonyLib;
+using System.Collections.Generic;
+using SolastaModApi;
 using static SolastaLevel20.Models.MultiClass;
+using System.Linq;
 
 namespace SolastaLevel20.Patches
 {
@@ -42,6 +45,37 @@ namespace SolastaLevel20.Patches
             {
                 flip = false;
             }
+        }
+
+        [HarmonyPatch(typeof(CharacterBuildingManager), "GrantFeatures")]
+        internal static class CharacterBuildingManager_GrantFeatures_Patch
+        {
+            internal static void Prefix(CharacterBuildingManager __instance, List<FeatureDefinition> grantedFeatures, string tag, bool clearPrevious = true, string optionalTagToCheck = null)
+            {
+                //If we are adding a level higher than level 1, exclude some features that would normally be added to a level 1 character
+                if (__instance.HeroCharacter.ClassesHistory.Count > 1)
+                {
+                    grantedFeatures.RemoveAll(feature => FeaturesToExcludeFromMulticlassLevels.Contains(feature));
+                    
+                    //Also need to add logic to add extra skill points here
+                }
+            }
+
+            private static readonly FeatureDefinition[] FeaturesToExcludeFromMulticlassLevels = new FeatureDefinition[]
+            {
+                DatabaseHelper.FeatureDefinitionPointPools.PointPoolClericSkillPoints,
+                DatabaseHelper.FeatureDefinitionPointPools.PointPoolFighterSkillPoints,
+                DatabaseHelper.FeatureDefinitionPointPools.PointPoolPaladinSkillPoints,
+                DatabaseHelper.FeatureDefinitionPointPools.PointPoolRangerSkillPoints,
+                DatabaseHelper.FeatureDefinitionPointPools.PointPoolRogueSkillPoints,
+                DatabaseHelper.FeatureDefinitionPointPools.PointPoolWizardSkillPoints,
+                DatabaseHelper.FeatureDefinitionProficiencys.ProficiencyClericSavingThrow,
+                DatabaseHelper.FeatureDefinitionProficiencys.ProficiencyFighterSavingThrow,
+                DatabaseHelper.FeatureDefinitionProficiencys.ProficiencyPaladinSavingThrow,
+                DatabaseHelper.FeatureDefinitionProficiencys.ProficiencyRangerSavingThrow,
+                DatabaseHelper.FeatureDefinitionProficiencys.ProficiencyRogueSavingThrow,
+                DatabaseHelper.FeatureDefinitionProficiencys.ProficiencyWizardSavingThrow,
+            };
         }
     }
 }


### PR DESCRIPTION
Add patch for GrantFeatures which removes features that should not be granted to a multiclass level up

The initial 1st level Skill points should not be added to characters that multiclass.
E.g. you should not get any Cleric skill points if you don't start as a cleric.
Only Bard/Ranger/Rogue add skill points when multiclassed into, and they only add one instead of the regular amount the get at level 1.  This patch will have to be expanded upon to do that.
Also removes the saving throw proficiencies from being added when multiclassing into another class.  You should only get saving throws from your initial class.