### PR TITLE
Foe Slayer

### DIFF
--- a/SolastaLevel20/Models/Classes/RangerBuilder.cs
+++ b/SolastaLevel20/Models/Classes/RangerBuilder.cs
@@ -4,6 +4,7 @@ using static SolastaModApi.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionCastSpells;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionFeatureSets;
 using static SolastaLevel20.Models.Features.ActionAffinityRangerVanishActionBuilder;
+using static SolastaLevel20.Models.Features.FeatureSetRangerFoeSlayerBuilder;
 
 namespace SolastaLevel20.Models.Classes
 {
@@ -17,7 +18,7 @@ namespace SolastaLevel20.Models.Classes
                 new FeatureUnlockByLevel(FeatureSetAbilityScoreChoice, 16),
                 // TODO 18: Feral Senses
                 new FeatureUnlockByLevel(FeatureSetAbilityScoreChoice, 19),
-                // TODO 20: Foe Slayer
+                new FeatureUnlockByLevel(FeatureSetRangerFoeSlayer, 20)
             });
 
             CastSpellRanger.SetSpellCastingLevel(5);

--- a/SolastaLevel20/Models/Features/FeatureSetRangerFoeSlayerBuilder.cs
+++ b/SolastaLevel20/Models/Features/FeatureSetRangerFoeSlayerBuilder.cs
@@ -1,0 +1,398 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using SolastaModApi;
+using SolastaModApi.Extensions;
+using static SolastaModApi.DatabaseHelper.FeatureDefinitionPowers;
+using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
+
+using SolastaModHelpers;
+using SolastaModHelpers.Helpers;
+using SolastaModHelpers.NewFeatureDefinitions;
+
+namespace SolastaLevel20.Models.Features
+{
+    internal class FeatureSetRangerFoeSlayerBuilder : BaseDefinitionBuilder<FeatureDefinitionFeatureSet>
+    {
+        const string FeatureSetRangerFoeSlayerName = "ZSFeatureSetRangerFoeSlayer";
+        const string FeatureSetRangerFoeSlayerGuid = "11001D8E-12FE-436E-AF95-D9644B7EEF1D";
+
+
+        protected FeatureSetRangerFoeSlayerBuilder(string name, string guid) : base(DatabaseHelper.FeatureDefinitionFeatureSets.FeatureSetShadowTamerDarkSlayer, name, guid)
+        {
+            var foe_slayer_avail_condition = buildConditionFoeSlayerAvailable();
+            var foe_slayer_used_condition = buildConditionFoeSlayerUsed();
+            var foe_slayer_avail = buildFeatureFoeSlayerAvailable(foe_slayer_avail_condition);
+            var foe_slayer_damage = buildPowerFoeSlayerDamage(foe_slayer_avail_condition, foe_slayer_used_condition);
+            var foe_slayer_attack = buildPowerFoeSlayerAttack(foe_slayer_avail_condition, foe_slayer_used_condition);
+            var foe_slayer_used = buildFeatureFoeSlayerUsed
+            (
+                foe_slayer_used_condition,
+                new List<FeatureDefinitionPower>()
+                {
+                    foe_slayer_damage,
+                    foe_slayer_attack
+                }
+            );
+
+            Definition.GuiPresentation.Title = "Feature/&RangerFeatureSetFoeSlayerTitle";
+            Definition.GuiPresentation.Description = "Feature/&RangerFeatureSetFoeSlayerDescription";
+
+            Definition.FeatureSet.Clear();
+            Definition.FeatureSet.Add(foe_slayer_avail);
+            Definition.FeatureSet.Add(foe_slayer_damage);
+            Definition.FeatureSet.Add(foe_slayer_attack);
+            Definition.FeatureSet.Add(foe_slayer_used);
+
+            Definition.SetEnumerateInDescription(false);
+            Definition.SetMode(FeatureDefinitionFeatureSet.FeatureSetMode.Union);
+        }
+
+        private static FeatureDefinitionFeatureSet CreateAndAddToDB(string name, string guid)
+            => new FeatureSetRangerFoeSlayerBuilder(name, guid).AddToDB();
+
+        public static readonly FeatureDefinitionFeatureSet FeatureSetRangerFoeSlayer
+            = CreateAndAddToDB(FeatureSetRangerFoeSlayerName, FeatureSetRangerFoeSlayerGuid);
+
+        private static ConditionDefinition buildConditionFoeSlayerAvailable()
+        {
+            var condition = ConditionBuilder.createConditionWithInterruptions
+            (
+                "ZSConditionRangerFoeSlayerAvailable",
+                "B9B7D2DB-365C-4FA9-A3FB-0E901B4783F7",
+                Common.common_no_title,
+                Common.common_no_title,
+                null,
+                ConditionMagicalWeapon,
+                new RuleDefinitions.ConditionInterruption[] { RuleDefinitions.ConditionInterruption.Attacks }
+            );
+
+            condition.SetSilentWhenAdded(true);
+            condition.SetSilentWhenRemoved(true);
+
+            condition.GuiPresentation.SetHidden(true);
+
+            return condition;
+        }
+
+        private static ConditionDefinition buildConditionFoeSlayerUsed()
+        {
+            var condition = ConditionBuilder.createCondition
+            (
+                "ZSConditionRangerFoeSlayerUsed",
+                "4F748DD5-14CA-4986-A871-8D459357F1C8",
+                Common.common_no_title,
+                Common.common_no_title,
+                null,
+                ConditionMagicalWeapon
+            );
+
+            condition.SetSilentWhenAdded(true);
+            condition.SetSilentWhenRemoved(true);
+
+            condition.GuiPresentation.SetHidden(true);
+
+            return condition;
+        }
+
+        private static FeatureDefinitionFoeSlayerAttackingFavored buildFeatureFoeSlayerAvailable(ConditionDefinition condition)
+        {
+            return FeatureBuilder<FeatureDefinitionFoeSlayerAttackingFavored>.createFeature
+            (
+                "ZSFeatureRangerFoeSlayerAvailable",
+                "AE51E473-0711-46C7-B6D6-F671A17243F0",
+                Common.common_no_title,
+                Common.common_no_title,
+                Common.common_no_icon,
+                a =>
+                {
+                    a.condition = condition;
+                    a.durationType = RuleDefinitions.DurationType.Turn;
+                    a.durationValue = 1;
+                    a.turnOccurence = RuleDefinitions.TurnOccurenceType.EndOfTurn;
+                }
+            );
+        }
+
+        private static ApplyConditionOnPowerUseToSelf buildFeatureFoeSlayerUsed(ConditionDefinition condition, List<FeatureDefinitionPower> foe_slayer_powers)
+        {
+            return FeatureBuilder<ApplyConditionOnPowerUseToSelf>.createFeature
+            (
+                "ZSFeatureRangerFoeSlayerUsed",
+                "A00B2D1D-A8E2-4A04-B104-BA2BC682E947",
+                Common.common_no_title,
+                Common.common_no_title,
+                Common.common_no_icon,
+                a =>
+                {
+                    a.condition = condition;
+                    a.durationType = RuleDefinitions.DurationType.Turn;
+                    a.durationValue = 1;
+                    a.powers = foe_slayer_powers;
+                }
+            );
+        }
+
+        private static PowerWithRestrictions buildPowerFoeSlayerDamage(ConditionDefinition avail_condition, ConditionDefinition restrict_condition)
+        {
+            // This looks stupendously weird, but if I set Bonus Damage to 0 and use 0 dice, the game
+            // hangs for 10-15 seconds on foe slayer damage. So the compensate, the Foe Slayer
+            // Damage calculation is 1d1 + Wisdom Mod - 1, which lets the game "roll" a dice and
+            // prevents a hang. If a future update of the game "fixes" this, then it can easily
+            // be set to BonusDamage = 0 and DiceNumber = 0.
+            var damage_form = new DamageForm();
+            damage_form.SetBonusDamage(-1);
+            damage_form.SetDamageType("DamagePiercing");
+            damage_form.SetDiceNumber(1);
+            damage_form.SetDieType(RuleDefinitions.DieType.D1);
+            damage_form.SetHealFromInflictedDamage(RuleDefinitions.HealFromInflictedDamage.Never);
+
+            var effect_form = new EffectForm();
+            effect_form.SetFormType(EffectForm.EffectFormType.Damage);
+            effect_form.SetDamageForm(damage_form);
+            effect_form.SetApplyAbilityBonus(true);
+
+            var effect_description = new EffectDescription();
+            effect_description.SetCanBePlacedOnCharacter(true);
+            effect_description.SetCreatedByCharacter(true);
+            effect_description.SetRangeType(RuleDefinitions.RangeType.RangeHit);
+            effect_description.SetTargetSide(RuleDefinitions.Side.Enemy);
+            effect_description.SetTargetType(RuleDefinitions.TargetType.Individuals);
+            effect_description.SetDurationParameter(1);
+            effect_description.SetDurationType(RuleDefinitions.DurationType.Turn);
+            effect_description.EffectForms.Clear();
+            effect_description.EffectForms.Add(effect_form);
+
+            var power = GenericPowerBuilder<PowerWithRestrictions>.createPower
+            (
+                "ZSPowerRangerFoeSlayerDamage",
+                "172AA353-C0A1-4648-B9F3-5ACA0B814D5B",
+                "Feature/&RangerFeatureSetFoeSlayerTitle",
+                Common.common_no_title,
+                PowerDomainBattleDecisiveStrike.GuiPresentation.SpriteReference,
+                effect_description,
+                RuleDefinitions.ActivationTime.OnAttackHit,
+                2,
+                RuleDefinitions.UsesDetermination.Fixed,
+                RuleDefinitions.RechargeRate.AtWill,
+                Stats.Wisdom,
+                Stats.Wisdom,
+                1,
+                false
+            );
+
+            power.SetShortTitleOverride("Foe Slayer");
+
+            power.restrictions = new List<IRestriction>()
+            {
+                new HasConditionRestriction(avail_condition),
+                new NoConditionRestriction(restrict_condition)
+            };
+
+            power.checkReaction = true;
+
+            return power;
+        }
+
+        private static PowerWithRestrictions buildPowerFoeSlayerAttack(ConditionDefinition avail_condition, ConditionDefinition restrict_condition)
+        {
+            var attack_wis = FeatureBuilder<FeatureDefinitionFoeSlayerAddWisdomAttack>.createFeature
+            (
+                "ZSAttackModifierRangerFoeSlayerAttack",
+                "1074AA14-1BDF-444F-B1BC-BF168F4133E2",
+                Common.common_no_title,
+                Common.common_no_title,
+                null
+            );
+
+            var condition = ConditionBuilder.createConditionWithInterruptions
+            (
+                "ZSConditionRangerFoeSlayerAttack",
+                "B6A524C2-01C0-4B83-9E1F-8B02FE13A990",
+                "Feature/&RangerFeatureSetFoeSlayerTitle",
+                Common.common_no_title,
+                null,
+                ConditionMagicalWeapon,
+                new RuleDefinitions.ConditionInterruption[] { RuleDefinitions.ConditionInterruption.Attacks },
+                attack_wis
+            );
+            
+            condition.SetSilentWhenAdded(true);
+            condition.SetSilentWhenRemoved(true);
+            condition.GuiPresentation.SetHidden(true);
+            condition.SetConditionType(RuleDefinitions.ConditionType.Beneficial);
+            condition.SetDurationParameter(1);
+            condition.SetDurationType(RuleDefinitions.DurationType.Turn);
+
+            var condition_form = new ConditionForm();
+            condition_form.SetApplyToSelf(true);
+            condition_form.SetOperation(ConditionForm.ConditionOperation.Add);
+            condition_form.SetConditionDefinition(condition);
+
+            var effect_form = new EffectForm();
+            effect_form.SetFormType(EffectForm.EffectFormType.Condition);
+            effect_form.SetConditionForm(condition_form);
+            effect_form.SetApplyAbilityBonus(true);
+
+            var effect_description = new EffectDescription();
+            effect_description.SetCanBePlacedOnCharacter(true);
+            effect_description.SetCreatedByCharacter(true);
+            effect_description.SetRangeType(RuleDefinitions.RangeType.Self);
+            effect_description.SetTargetSide(RuleDefinitions.Side.Ally);
+            effect_description.SetTargetType(RuleDefinitions.TargetType.Self);
+            effect_description.SetDurationParameter(1);
+            effect_description.SetDurationType(RuleDefinitions.DurationType.Turn);
+            effect_description.EffectForms.Clear();
+            effect_description.EffectForms.Add(effect_form);
+
+            var power = GenericPowerBuilder<FeatureDefinitionFoeSlayerPowerOnAttack>.createPower
+            (
+                "ZSPowerRangerFoeSlayerAttack",
+                "493B92B2-FAF3-46A7-84F8-A753D4F2A1AF",
+                Common.common_no_title,
+                Common.common_no_title,
+                PowerDomainBattleDecisiveStrike.GuiPresentation.SpriteReference,
+                effect_description,
+                RuleDefinitions.ActivationTime.Reaction,
+                2,
+                RuleDefinitions.UsesDetermination.Fixed,
+                RuleDefinitions.RechargeRate.AtWill,
+                Stats.Wisdom,
+                Stats.Wisdom,
+                1,
+                false
+            );
+
+            power.SetShortTitleOverride("Foe Slayer");
+
+            power.restrictions = new List<IRestriction>()
+            {
+                new HasConditionRestriction(avail_condition),
+                new NoConditionRestriction(restrict_condition)
+            };
+
+            power.checkReaction = true;
+
+            return power;
+        }
+    }
+
+    public class FeatureDefinitionFoeSlayerAttackingFavored : FeatureDefinition, IInitiatorApplyEffectOnAttack
+    {
+        public ConditionDefinition condition;
+        public int durationValue;
+        public RuleDefinitions.DurationType durationType;
+        public RuleDefinitions.TurnOccurenceType turnOccurence;
+
+        public void processAttackInitiator(GameLocationCharacter attacker, GameLocationCharacter defender, ActionModifier attack_modifier, RulesetAttackMode attack_mode)
+        {
+            var favored_enemies = new List<string>();
+
+            // Get all favored enemies
+            attacker.RulesetCharacter.EnumerateFeaturesToBrowse<FeatureDefinitionAdditionalDamage>(attacker.RulesetCharacter.FeaturesToBrowse);
+            
+            favored_enemies.Clear();
+            
+            foreach (FeatureDefinition feature in attacker.RulesetCharacter.FeaturesToBrowse)
+            {
+                var damage_feature = feature as FeatureDefinitionAdditionalDamage;
+            
+                if (damage_feature.Name.Contains("AdditionalDamageRangerFavoredEnemy"))
+                {
+                    favored_enemies.Add(damage_feature.RequiredCharacterFamily.Name);
+                }
+            }
+
+            // Apply a condition if we're attacking a favored enemy
+            if (favored_enemies.Contains(defender.RulesetCharacter.CharacterFamily))
+            {
+                RulesetCondition active_condition = RulesetCondition.CreateActiveCondition(attacker.RulesetCharacter.Guid,
+                                                                                           condition, RuleDefinitions.DurationType.Turn, 1, RuleDefinitions.TurnOccurenceType.EndOfTurn,
+                                                                                           attacker.RulesetCharacter.Guid,
+                                                                                           attacker.RulesetCharacter.CurrentFaction.Name);
+                attacker.RulesetCharacter.AddConditionOfCategory("10Combat", active_condition, true);
+            }
+        }
+    }
+
+    public class FeatureDefinitionFoeSlayerPowerOnAttack : PowerWithRestrictions, IReactionPowerOnAttackAttempt
+    {
+        bool IReactionPowerOnAttackAttempt.canBeUsedOnAttackAttempt(GameLocationCharacter caster, GameLocationCharacter attacker, GameLocationCharacter defender, ActionModifier attack_modifier, RulesetAttackMode attack_mode)
+        {
+            var prerolled_data = AttackRollsData.getPrerolledData(attacker);
+
+            if (caster != attacker)
+            {
+                return false;
+            }
+            
+            if ( prerolled_data.outcome != RuleDefinitions.RollOutcome.Failure )
+            {
+                return false;
+            }
+            
+            var effect = this.EffectDescription;
+            if (effect == null)
+            {
+                return false;
+            }
+            
+            if (attack_mode == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    public class FeatureDefinitionFoeSlayerAddWisdomAttack : FeatureDefinitionAffinity, ICombatAffinityProvider,  IAffinityProvider, IInitiativeModifier
+    {
+        private bool autoCritical = false;
+        private bool criticalHitImmunity = false;
+        private bool ignoreCover = false;
+        private RuleDefinitions.SituationalContext situationalContext = RuleDefinitions.SituationalContext.None;
+        private ConditionDefinition requiredTargetCondition = null;
+
+        public bool AutoCritical => this.autoCritical;
+        public bool CriticalHitImmunity => this.criticalHitImmunity;
+        public bool IgnoreCover => this.ignoreCover;
+        public RuleDefinitions.SituationalContext SituationalContext => this.situationalContext;
+        public ConditionDefinition RequiredTargetCondition => this.requiredTargetCondition;
+
+        public void RefreshInitiativeBonus(ref int advantageValue)
+        {
+            return;
+        }
+
+        public bool IsImmuneToOpportunityAttack(RulesetCharacter myself, RulesetCharacter attacker) => false;
+
+        public RuleDefinitions.AdvantageType GetAdvantageOnOpportunityAttackOnMe(
+          RulesetCharacter myself,
+          RulesetCharacter attacker)
+        {
+            return RuleDefinitions.AdvantageType.None;
+        }
+
+        public void ComputeAttackModifier(RulesetCharacter myself, RulesetCharacter defender, RulesetAttackMode attackMode, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+        {
+            if (myself == null || defender == null || attackModifier == null)
+            {
+                Trace.LogWarning("Invalid parameters in ComputeAttackModifier");
+            }
+            else
+            {
+                var num = AttributeDefinitions.ComputeAbilityScoreModifier(myself.GetAttribute(Stats.Wisdom).CurrentValue);
+                attackModifier.AttackRollModifier += num;
+                attackModifier.AttacktoHitTrends.Add(new RuleDefinitions.TrendInfo(num, featureOrigin.sourceType, featureOrigin.sourceName, (object)null));
+            }
+        }
+
+        public void ComputeDefenseModifier(RulesetCharacter myself, RulesetCharacter attacker, int sustainedAttacks, bool defenderAlreadyAttackedByAttackerThisTurn, ActionModifier attackModifier, RuleDefinitions.FeatureOrigin featureOrigin)
+        {
+            return;
+        }
+    }
+}

--- a/SolastaLevel20/SolastaLevel20.csproj
+++ b/SolastaLevel20/SolastaLevel20.csproj
@@ -55,6 +55,9 @@
 			<HintPath>$([System.IO.Path]::Combine($(SolastaInstallDir), 'Mods\SolastaModApi\SolastaModApi.dll'))</HintPath>
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="SolastaModHelpers">
+		  <HintPath>..\..\..\Games\Steam\steamapps\common\Slasta_COTM\Mods\SolastaModHelpers\SolastaModHelpers.dll</HintPath>
+		</Reference>
     	<Reference Include="Unity.Addressables">
 			<HintPath>$([System.IO.Path]::Combine($(SolastaInstallDir), 'Solasta_Data\Managed\Unity.Addressables.dll'))</HintPath>
 			<Private>false</Private>

--- a/SolastaLevel20/SolastaLevel20.csproj
+++ b/SolastaLevel20/SolastaLevel20.csproj
@@ -56,9 +56,10 @@
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="SolastaModHelpers">
-		  <HintPath>..\..\..\Games\Steam\steamapps\common\Slasta_COTM\Mods\SolastaModHelpers\SolastaModHelpers.dll</HintPath>
+			<HintPath>$([System.IO.Path]::Combine($(SolastaInstallDir), 'Mods\SolastaModApi\SolastaModHelpers.dll'))</HintPath>
+			<Private>false</Private>
 		</Reference>
-    	<Reference Include="Unity.Addressables">
+    	        <Reference Include="Unity.Addressables">
 			<HintPath>$([System.IO.Path]::Combine($(SolastaInstallDir), 'Solasta_Data\Managed\Unity.Addressables.dll'))</HintPath>
 			<Private>false</Private>
 		</Reference>

--- a/SolastaLevel20/Translations-en.txt
+++ b/SolastaLevel20/Translations-en.txt
@@ -12,7 +12,7 @@ Feature/&ProficiencyRogueBlindSenseTitle	Blindsense
 Feature/&ProficiencyRogueBlindSenseDescription	Starting at 14th level, if you are able to hear, you are aware of the location of any hidden or invisible creature within 10 feet of you.
 Feature/&IndomitableResistanceAddTitle	Indomitable Resistance (increased)
 Feature/&IndomitableResistanceAddDescription	+1 Indomitable Resistance use between rests.
-Feature/&IndomitableResitanceTitle	Indomitable Resitance
+Feature/&IndomitableResistanceTitle	Indomitable Resitance
 Reaction/&SpendPowerZSPowerRangerFoeSlayerDamageTitle	Foe Slayer
 Reaction/&SpendPowerZSPowerRangerFoeSlayerDamageDescription	Add your Wisdom modifier to your damage roll.
 Reaction/&SpendPowerZSPowerRangerFoeSlayerDamageReactTitle	Foe Slayer

--- a/SolastaLevel20/Translations-en.txt
+++ b/SolastaLevel20/Translations-en.txt
@@ -1,5 +1,7 @@
 Feature/&RangerVanishActionTitle	Vanish
 Feature/&RangerVanishActionDescription	Starting at 14th level, you can use the Hide action as a bonus action on your turn.
+Feature/&RangerFeatureSetFoeSlayerTitle	Foe Slayer
+Feature/&RangerFeatureSetFoeSlayerDescription	At 20th level, you become an unparalleled Hunter of your enemies. Once on each of your turns, you can add your Wisdom modifier to the Attack roll or the damage roll of an Attack you make against one of your Favored enemies.
 Feature/&PowerPaladinAuraOfProtection18Title	Improved Aura of Protection
 Feature/&PowerPaladinAuraOfProtection18Description	You and your allies within 30ft cannot be frightened.
 Feature/&PowerPaladinAuraOfCourage18Title	Improved Aura of Courage
@@ -10,4 +12,12 @@ Feature/&ProficiencyRogueBlindSenseTitle	Blindsense
 Feature/&ProficiencyRogueBlindSenseDescription	Starting at 14th level, if you are able to hear, you are aware of the location of any hidden or invisible creature within 10 feet of you.
 Feature/&IndomitableResistanceAddTitle	Indomitable Resistance (increased)
 Feature/&IndomitableResistanceAddDescription	+1 Indomitable Resistance use between rests.
-Feature/&IndomitableResistanceTitle	Indomitable Resitance
+Feature/&IndomitableResitanceTitle	Indomitable Resitance
+Reaction/&SpendPowerZSPowerRangerFoeSlayerDamageTitle	Foe Slayer
+Reaction/&SpendPowerZSPowerRangerFoeSlayerDamageDescription	Add your Wisdom modifier to your damage roll.
+Reaction/&SpendPowerZSPowerRangerFoeSlayerDamageReactTitle	Foe Slayer
+Reaction/&SpendPowerZSPowerRangerFoeSlayerDamageReactDescription	Add your Wisdom modifier to your damage roll.
+Reaction/&UseZSPowerRangerFoeSlayerAttackTitle	Foe Slayer
+Reaction/&UseZSPowerRangerFoeSlayerAttackDescription	Add your Wisdom modifier to your attack roll.
+Reaction/&UseZSPowerRangerFoeSlayerAttackReactTitle	Foe Slayer
+Reaction/&UseZSPowerRangerFoeSlayerDamageReactDescription	Add your Wisdom modifier to your attack roll.


### PR DESCRIPTION
Implemented the Ranger Level 20 Class Feature Foe Slayer. Works as a reaction to either damaging a favored enemy, or to missing an attack against a favored enemy, where the Ranger may add their wisdom bonus to either attack or damage.

These changes require ModHelpers.

Feature Set and support methods are implemented in FeatureSetRangerFoeSlayerBuilder.cs